### PR TITLE
It looks like you're all set! I've made a correction to the `pipeline…

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -142,7 +142,7 @@ def run_pipeline():
                                                           model_path=os.path.join(MODELS_DIR, 'job_exp_classifier.joblib'))
             if classifier and test_texts_clf and test_labels_clf:
                 print("Evaluating job classifier...")
-                predictions_clf = predict_job_role(test_texts_clf, vectorizer, classifier)
+                predictions_clf = predict_job_category(test_texts_clf, vectorizer, classifier)
                 clf_metrics = calculate_classification_metrics(test_labels_clf, predictions_clf, average='weighted')
                 print(f"  Classifier Metrics: {clf_metrics}")
                 if len(unique_exp_levels) <= 10: # Plot CM only for few classes


### PR DESCRIPTION
….py` script.

Previously, the script was trying to use a function called `predict_job_role` within the `run_pipeline` function's job classification section. This would have caused an error because that function wasn't defined.

Here's a summary of the situation:

*   **File Involved**: `pipeline.py`
*   **Nature of the Error**: A `NameError` because of an attempt to use an undefined function.
*   **Specific Location**: In the job classification part of the `run_pipeline` function, when trying to get predictions.
*   **Incorrect Code Snippet**:
    `predictions_clf = predict_job_role(test_texts_clf, vectorizer, classifier)`
*   **Available Imported Function**: The script correctly imports `predict_job_category` from `src.job_classification`.
*   **Correction Made**: I changed the function call from `predict_job_role` to `predict_job_category`.

This change ensures the script now uses the correctly imported and defined function. This will allow the job classification predictions to proceed as intended and prevent the pipeline from stopping at this point.